### PR TITLE
Fix deprecated references to /bower_components in development environment

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -139,13 +139,26 @@ gulp.task( "uglify", function() {
 		.pipe( gulp.dest( "dist/js" ) );
 });
 
+/** jQuery **/
+gulp.task("jquery", function() {
+	return gulp.src("node_modules/jquery/dist/jquery.js")
+		.pipe( $.sourcemaps.init() )
+		.pipe( $.sourcemaps.write( "." ) )
+		.pipe( gulp.dest( "src/js/lib" ) );
+});
+
+gulp.task("normalize", function() {
+	return gulp.src("node_modules/normalize.css/normalize.css")
+		.pipe( gulp.dest( "src/css/lib" ) );
+});
+
 /** `env` to 'production' */
 gulp.task( "envProduction", function() {
 	env = "production";
 });
 
 /** Livereload */
-gulp.task( "watch", [ "template", "styles", "jshint" ], function() {
+gulp.task( "watch", [ "template", "styles", "jshint", "modernizr", "jquery", "normalize" ], function() {
 	var server = $.livereload;
 	server.listen();
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -93,13 +93,13 @@ function html5blank_header_scripts() {
         if ( HTML5_DEBUG ) {
             // jQuery
             wp_deregister_script( 'jquery' );
-            wp_register_script( 'jquery', get_template_directory_uri() . '/bower_components/jquery/dist/jquery.js', array(), '1.11.1' );
+            wp_register_script( 'jquery', get_template_directory_uri() . '/js/lib/jquery.js', array(), '1.11.1' );
 
             // Conditionizr
             wp_register_script( 'conditionizr', get_template_directory_uri() . '/js/lib/conditionizr-4.3.0.min.js', array(), '4.3.0' );
 
             // Modernizr
-            wp_register_script( 'modernizr', get_template_directory_uri() . '/bower_components/modernizr/modernizr.js', array(), '2.8.3' );
+            wp_register_script( 'modernizr', get_template_directory_uri() . '/js/lib/modernizr.js', array(), '2.8.3' );
 
             // Custom scripts
             wp_register_script(
@@ -138,7 +138,7 @@ function html5blank_conditional_scripts() {
 function html5blank_styles() {
     if ( HTML5_DEBUG ) {
         // normalize-css
-        wp_register_style( 'normalize', get_template_directory_uri() . '/bower_components/normalize.css/normalize.css', array(), '3.0.1' );
+        wp_register_style( 'normalize', get_template_directory_uri() . '/css/lib/normalize.css', array(), '7.0.0' );
 
         // Custom CSS
         wp_register_style( 'html5blank', get_template_directory_uri() . '/style.css', array( 'normalize' ), '1.0' );


### PR DESCRIPTION
Solving issue #181 .

Further improvement possibility:
gulpfile.js could be cleaned up or ordered in a new structure for better readability.