### PR TITLE
use esc_html__() instead of esc_html_e()

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -279,7 +279,7 @@ function html5wp_excerpt( $length_callback = '', $more_callback = '' ) {
 // Custom View Article link to Post
 function html5_blank_view_article( $more ) {
     global $post;
-    return '... <a class="view-article" href="' . get_permalink( $post->ID ) . '">' . esc_html_e( 'View Article', 'html5blank' ) . '</a>';
+    return '... <a class="view-article" href="' . get_permalink( $post->ID ) . '">' . esc_html__( 'View Article', 'html5blank' ) . '</a>';
 }
 
 // Remove Admin bar


### PR DESCRIPTION
When using `esc_html_e()`, the value is [echoed directly](https://codex.wordpress.org/Function_Reference/esc_html_e). 

In this case, it should be returned instead, which is achieved by using `esc_html__()`, accodring to [the documentation](https://codex.wordpress.org/Function_Reference/esc_html_2).